### PR TITLE
Highlight bug fix

### DIFF
--- a/vscode-antimony/src/extension.ts
+++ b/vscode-antimony/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import * as utils from './utils/utils';
 import * as path from 'path';
-import { TabChangeEvent } from 'vscode';
 import {
 	LanguageClient,
 	LanguageClientOptions,

--- a/vscode-antimony/src/extension.ts
+++ b/vscode-antimony/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import * as utils from './utils/utils';
 import * as path from 'path';
+import { TabChangeEvent } from 'vscode';
 import {
 	LanguageClient,
 	LanguageClientOptions,
@@ -42,6 +43,11 @@ function updateDecorations() {
 		vscode.commands.executeCommand('antimony.getAnnotation', uri).then(async (result: string) => {
 
 			annVars = result;
+			if (annVars == "" || annVars == null || annVars == " "){
+				vscode.workspace.getConfiguration('vscode-antimony').update('annotatedVariableIndicatorOn', false, true);
+				annDecorationType.dispose();
+				return;
+			}
 			regexFromAnnVarsHelp = new RegExp(annVars,'g');
 			regexFromAnnVars = new RegExp('\\b(' + regexFromAnnVarsHelp.source + ')\\b', 'g');
 
@@ -55,7 +61,7 @@ function updateDecorations() {
 			while ((match = regexFromAnnVars.exec(text))) {
 				const startPos = activeEditor.document.positionAt(match.index);
 				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
-				const decoration = { range: new vscode.Range(startPos, endPos), hoverMessage: 'Annotated Variable' };
+				const decoration = { range: new vscode.Range(startPos, endPos) };
 					annotated.push(decoration);
 			}
 			activeEditor.setDecorations(annDecorationType, annotated);


### PR DESCRIPTION
Bug: When switching models in vscode, the annotations would not reset and the hover messages said "loading...". The visual indications was also stuck in "on" mode and would not switch off. This might be because the other models do not have annotated variables.

This bug fix turns off the visual indications when there are no annotated variables, thus fixing the bug of the constant loading hover message.